### PR TITLE
Fix: Detect Mixture of "_P-" and "_UP-" was Using Lower-Case "p"

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -256,7 +256,7 @@ namespace OpenKNXproducer
                 string lId = lNode.Attributes.GetNamedItem("Id").Value;
                 string lId2 = "";
                 if (lId.Contains("_P-"))
-                    lId2 = lId.Replace("_p-", "_UP-");
+                    lId2 = lId.Replace("_P-", "_UP-");
                 else if (lId.Contains("_UP-"))
                     lId2 = lId.Replace("_UP-", "_P-");
                 if (gIds.ContainsKey(lId))


### PR DESCRIPTION
Beim Blick auf den letzten Commit entdeckt.

Gehe davon aus, dass ist ein Tipp-Fehler und (sofern hier kein Case-Insensitives Ersetzen erfolgt) wird dazu führen, dass die Prüfung nicht funktioniert oder nur für die eine Richtung ein Fehler angezeigt wird.