### PR TITLE
Better support for translations

### DIFF
--- a/ProcessInclude.cs
+++ b/ProcessInclude.cs
@@ -247,6 +247,183 @@ namespace OpenKNXproducer
             MinVersionNodes.AddRange(lMinVersionNodes.Cast<XmlNode>());
         }
 
+        private static XmlNode FindTranslationElement(XmlNode iTranslationUnit, string iRefId)
+        {
+            if (iTranslationUnit == null) return null;
+            foreach (XmlNode lChild in iTranslationUnit.ChildNodes)
+            {
+                if (lChild.NodeType != XmlNodeType.Element) continue;
+                if (lChild.Name != "TranslationElement") continue;
+                if (lChild.NodeAttr("RefId") == iRefId) return lChild;
+            }
+            return null;
+        }
+
+        private static XmlNode EnsureStaticLanguage(XmlDocument iDoc, XmlNode iTargetNode, string iLanguage)
+        {
+            XmlNode lStatic = iTargetNode.SelectSingleNode("/KNX/ManufacturerData/Manufacturer/ApplicationPrograms/ApplicationProgram/Static");
+            if (lStatic == null) return null;
+            XmlNode lLanguages = lStatic.SelectSingleNode("Languages");
+            if (lLanguages == null)
+            {
+                lLanguages = iDoc.CreateElement("Languages");
+                lStatic.AppendChild(lLanguages);
+            }
+            foreach (XmlNode lLang in lLanguages.ChildNodes)
+            {
+                if (lLang.NodeType != XmlNodeType.Element) continue;
+                if (lLang.Name == "Language" && lLang.NodeAttr("Identifier") == iLanguage) return lLang;
+            }
+            XmlNode lNewLang = iDoc.CreateElement("Language");
+            XmlAttribute lId = iDoc.CreateAttribute("Identifier");
+            lId.Value = iLanguage;
+            lNewLang.Attributes.Append(lId);
+            lLanguages.AppendChild(lNewLang);
+            return lNewLang;
+        }
+
+        private static XmlNode EnsureManufacturerLanguage(XmlDocument iDoc, XmlNode iTargetNode, string iLanguage)
+        {
+            XmlNode lManufacturer = iTargetNode.SelectSingleNode("/KNX/ManufacturerData/Manufacturer");
+            if (lManufacturer == null) return null;
+            XmlNode lLanguages = lManufacturer.SelectSingleNode("Languages");
+            if (lLanguages == null)
+            {
+                lLanguages = iDoc.CreateElement("Languages");
+                lManufacturer.AppendChild(lLanguages);
+            }
+            foreach (XmlNode lLang in lLanguages.ChildNodes)
+            {
+                if (lLang.NodeType != XmlNodeType.Element) continue;
+                if (lLang.Name == "Language" && lLang.NodeAttr("Identifier") == iLanguage) return lLang;
+            }
+            XmlNode lNewLang = iDoc.CreateElement("Language");
+            XmlAttribute lId = iDoc.CreateAttribute("Identifier");
+            lId.Value = iLanguage;
+            lNewLang.Attributes.Append(lId);
+            lLanguages.AppendChild(lNewLang);
+            return lNewLang;
+        }
+
+        private static XmlNode EnsureTranslationUnit(XmlDocument iDoc, XmlNode iLanguageNode, string iApplicationId)
+        {
+            if (iLanguageNode == null) return null;
+            foreach (XmlNode lChild in iLanguageNode.ChildNodes)
+            {
+                if (lChild.NodeType != XmlNodeType.Element) continue;
+                if (lChild.Name == "TranslationUnit" && lChild.NodeAttr("RefId") == iApplicationId) return lChild;
+            }
+            XmlNode lUnit = iDoc.CreateElement("TranslationUnit");
+            XmlAttribute lRefId = iDoc.CreateAttribute("RefId");
+            lRefId.Value = iApplicationId;
+            lUnit.Attributes.Append(lRefId);
+            iLanguageNode.AppendChild(lUnit);
+            return lUnit;
+        }
+
+        public static void ConvertInlineTranslations(XmlNode iTargetNode)
+        {
+            XmlDocument lDoc = (iTargetNode as XmlDocument) ?? iTargetNode.OwnerDocument;
+            if (lDoc?.DocumentElement == null) return;
+
+            XmlNamespaceManager lNsMgr = new XmlNamespaceManager(lDoc.NameTable);
+            lNsMgr.AddNamespace("oknxp", ProcessInclude.cOwnNamespace);
+
+            XmlNode lApplication = iTargetNode.SelectSingleNode("/KNX/ManufacturerData/Manufacturer/ApplicationPrograms/ApplicationProgram");
+            string lApplicationId = lApplication?.NodeAttr("Id");
+            if (string.IsNullOrEmpty(lApplicationId)) return;
+
+            XmlNodeList lInlineTranslations = iTargetNode.SelectNodes("//oknxp:Translation", lNsMgr);
+            if (lInlineTranslations == null || lInlineTranslations.Count == 0) return;
+
+            List<XmlNode> lInlineNodes = new();
+            foreach (XmlNode lNode in lInlineTranslations) lInlineNodes.Add(lNode);
+
+            foreach (XmlNode lInline in lInlineNodes)
+            {
+                XmlNode lParent = lInline.ParentNode;
+                if (lParent == null)
+                {
+                    lInline.ParentNode?.RemoveChild(lInline);
+                    continue;
+                }
+
+                string lLanguage = lInline.NodeAttr("Language");
+                string lAttributeName = lInline.NodeAttr("AttributeName");
+                string lText = lInline.NodeAttr("Text");
+                if (string.IsNullOrEmpty(lLanguage))
+                {
+                    Program.Message(true, "Inline translation without Language found under {0}", lParent.Name);
+                    lParent.RemoveChild(lInline);
+                    continue;
+                }
+
+                string lParentId = lParent.NodeAttr("Id");
+                if (string.IsNullOrEmpty(lParentId))
+                {
+                    Program.Message(true, "Inline translation under {0} without Id is not supported", lParent.Name);
+                    lParent.RemoveChild(lInline);
+                    continue;
+                }
+
+                EnsureStaticLanguage(lDoc, iTargetNode, lLanguage);
+                XmlNode lLanguageNode = EnsureManufacturerLanguage(lDoc, iTargetNode, lLanguage);
+                XmlNode lTranslationUnit = EnsureTranslationUnit(lDoc, lLanguageNode, lApplicationId);
+
+                XmlNode lTranslationElement = FindTranslationElement(lTranslationUnit, lParentId);
+                if (lTranslationElement == null)
+                {
+                    lTranslationElement = lDoc.CreateElement("TranslationElement");
+                    XmlAttribute lRefId = lDoc.CreateAttribute("RefId");
+                    lRefId.Value = lParentId;
+                    lTranslationElement.Attributes.Append(lRefId);
+                    lTranslationUnit.AppendChild(lTranslationElement);
+                }
+
+                bool lAddedTranslation = false;
+                if (!string.IsNullOrEmpty(lAttributeName))
+                {
+                    if (lText == "")
+                    {
+                        Program.Message(true, "Inline translation with AttributeName but no Text under {0}", lParent.Name);
+                    }
+                    else
+                    {
+                        XmlNode lTranslation = lDoc.CreateElement("Translation");
+                        XmlAttribute lAttrName = lDoc.CreateAttribute("AttributeName");
+                        lAttrName.Value = lAttributeName;
+                        XmlAttribute lTextAttr = lDoc.CreateAttribute("Text");
+                        lTextAttr.Value = lText;
+                        lTranslation.Attributes.Append(lAttrName);
+                        lTranslation.Attributes.Append(lTextAttr);
+                        lTranslationElement.AppendChild(lTranslation);
+                        lAddedTranslation = true;
+                    }
+                }
+                else
+                {
+                    foreach (XmlAttribute lAttr in lInline.Attributes)
+                    {
+                        if (lAttr.Name == "Language") continue;
+                        XmlNode lTranslation = lDoc.CreateElement("Translation");
+                        XmlAttribute lAttrName = lDoc.CreateAttribute("AttributeName");
+                        lAttrName.Value = lAttr.Name;
+                        XmlAttribute lTextAttr = lDoc.CreateAttribute("Text");
+                        lTextAttr.Value = lAttr.Value;
+                        lTranslation.Attributes.Append(lAttrName);
+                        lTranslation.Attributes.Append(lTextAttr);
+                        lTranslationElement.AppendChild(lTranslation);
+                        lAddedTranslation = true;
+                    }
+                }
+
+                if (!lAddedTranslation)
+                    Program.Message(true, "Inline translation without translated attributes under {0}", lParent.Name);
+
+                lParent.RemoveChild(lInline);
+            }
+        }
+
         public static ProcessInclude Factory(string iXmlFileName, string iHeaderPrefixName)
         {
             ProcessInclude lInclude = null;
@@ -1488,7 +1665,12 @@ namespace OpenKNXproducer
                     lMemoryNode = lNode;
                 }
                 XmlNode lMemory = lMemoryNode.FirstChild;
-                while (lMemory != null && lMemory.NodeType == XmlNodeType.Comment) lMemory = lMemory.NextSibling;
+                while (lMemory != null && (lMemory.NodeType == XmlNodeType.Comment || (lMemory.Name == "Translation" && lMemory.NamespaceURI == ProcessInclude.cOwnNamespace)))
+                    lMemory = lMemory.NextSibling;
+                if (lMemory == null || lMemory.Attributes == null)
+                    continue;
+                if (lMemory.Attributes.GetNamedItem("Offset") == null || lMemory.Attributes.GetNamedItem("BitOffset") == null)
+                    continue;
                 if (lMemory != null && sParameterTypes.Count > 0)
                 {
                     // parse parameter type to fill additional information

--- a/ProcessInclude.cs
+++ b/ProcessInclude.cs
@@ -931,6 +931,31 @@ namespace OpenKNXproducer
                     ProcessChannel(iDefine, iChannel, iTargetNode, iInclude);
                 }
             }
+            // Ensure placeholders (%C%, %T%, etc.) in op:Translation children are replaced
+            ProcessTranslationChildren(iDefine, iChannel, iTargetNode, iInclude);
+        }
+
+        /// <summary>
+        /// Recursively walks descendants of <paramref name="iTargetNode"/> and
+        /// replaces template placeholders in the attributes of any
+        /// <c>op:Translation</c> element found.  This is safe to call even when
+        /// <see cref="ProcessChannel"/> has already visited the subtree because
+        /// the replacement functions are idempotent on already-resolved values.
+        /// </summary>
+        static void ProcessTranslationChildren(DefineContent iDefine, int iChannel, XmlNode iTargetNode, ProcessInclude iInclude)
+        {
+            foreach (XmlNode lChild in iTargetNode.ChildNodes)
+            {
+                if (lChild.NamespaceURI == cOwnNamespace && lChild.LocalName == "Translation")
+                {
+                    if (lChild.Attributes != null)
+                        ProcessAttributes(iDefine, iChannel, lChild, iInclude);
+                }
+                else if (lChild.HasChildNodes)
+                {
+                    ProcessTranslationChildren(iDefine, iChannel, lChild, iInclude);
+                }
+            }
         }
 
         static void ReplaceDocumentStrings(XmlNode iNode, string iSourceText, string iTargetText)

--- a/Program.cs
+++ b/Program.cs
@@ -1798,6 +1798,7 @@ namespace OpenKNXproducer
             if (lSuccess) lSuccess = EnsureEtsNamingConventionForKO(lInclude);
             if (lSuccess) lSuccess = PushUpdateChannelToFirstPosition(lXml);
             if (lSuccess && opts.ExchangeKoTexts) ExchangeKoTextAndFunctionText(lXml);
+            if (lSuccess) ProcessInclude.ConvertInlineTranslations(lInclude.GetDocument());
             string lTempXmlFileName = Path.GetTempFileName();
             File.Delete(lTempXmlFileName);
             if (opts.Debug) lTempXmlFileName = opts.XmlFileName;

--- a/doc/translations.md
+++ b/doc/translations.md
@@ -66,6 +66,22 @@ No manual editing of the generated XML is necessary. When imported into ETS, it 
 </Languages>
 ```
 
+## Template placeholders in translations
+
+`op:Translation` elements inside templates (channel definitions, etc.) can use
+the same `%C%`, `%T%`, and other placeholders as the parent element.
+OpenKNXproducer resolves these placeholders during template expansion, so
+translations that include channel-specific text work correctly:
+
+```xml
+<ComObject Id="%AID%_O-%TT%00008" Text="DFA %C%, Eingang 8" FunctionText="Eingang 8">
+  <op:Translation Language="en-US" Text="DFA %C%, input 8" FunctionText="Input 8" />
+</ComObject>
+```
+
+After expansion for channel 3 this produces a `TranslationElement` with
+`Text="DFA 3, input 8"`.
+
 ## Known limitation: renumbered IDs
 
 OpenKNXproducer renumbers `_PB-` (ParameterBlock) and `_PS-` (ParameterSeparator) IDs during processing. Because the `TranslationElement/@RefId` is written from the parent element's `Id` before renumbering takes place, these entries will not match the final IDs that ETS looks up. Use explicit `TranslationElement` entries with stable IDs (e.g. derived from a `Name` attribute via XPath) as a workaround until this is resolved.

--- a/doc/translations.md
+++ b/doc/translations.md
@@ -1,0 +1,71 @@
+﻿# Translations
+
+ETS expects translations to be included as `Languages`/`TranslationUnit`/`TranslationElement` elements under the `Manufacturer` tag. However this is problematic for OpenKNX as the config files extensively use dynamic `RefId` entries, which are computed when OpenKNXproducer compiles them. Additionally, it means the translations live in a completely different place to the primary language text, which makes it hard to validate translations.
+
+OpenKNXproducer can consume inline translations in the share XML without requiring you to manually edit the resulting `TranslationElement` nodes. Add `op:Translation` children to the element whose attributes you want to translate, and it will create the supporting `Languages`/`TranslationUnit`/`TranslationElement` entries that ETS expects.
+
+## Namespace declaration
+
+The OpenKNXproducer namespace must be declared on the root element of your XML file (it is typically already present):
+
+```xml
+xmlns:op="http://github.com/OpenKNX/OpenKNXproducer"
+```
+
+## Basic syntax
+
+For each element you want to translate, add an `op:Translation` child that specifies the language and the attributes to translate. Use the original attribute name:
+
+```xml
+<ParameterSeparator Id="%AID%_PS-nnn" Text="Allgemein" UIHint="Headline">
+  <op:Translation Language="en-US" Text="General" />
+</ParameterSeparator>
+```
+
+If the element has multiple attributes to translate (you only need to translate what is visible in ETS), specify each of them in a single `op:Translation` element:
+
+```xml
+<ComObject Id="%AID%_O-%TT%00007" Text="Diagnose" FunctionText="Diagnoseobjekt">
+  <op:Translation Language="en-US" Text="Diagnostics" FunctionText="Diagnostic object" />
+</ComObject>
+```
+
+Translatable attribute names: `Text`, `SuffixText`, `FunctionText`.
+
+## Rules
+
+- `Language` is required on every `op:Translation` (e.g. `en-US`).
+- At least one translatable attribute must be provided.
+- The parent element **must** have a stable `Id` attribute — the generated `TranslationElement/@RefId` is taken from it.
+- Do **not** add `op:Translation` to elements that have no `Id`.
+
+## How it works
+
+After processing, OpenKNXproducer:
+
+1. Ensures the target language exists under both:
+   - `/KNX/ManufacturerData/Manufacturer/ApplicationPrograms/ApplicationProgram/Static/Languages`
+   - `/KNX/ManufacturerData/Manufacturer/Languages`
+2. Ensures a `TranslationUnit` exists for the current application `Id`.
+3. For each `op:Translation`, adds a `TranslationElement` keyed by the parent element's `Id` and inserts a `Translation` child for each translated attribute.
+4. Removes the inline `op:Translation` node.
+
+No manual editing of the generated XML is necessary. When imported into ETS, it will show labels in the user's preferred language.
+
+## Resulting ETS structure (example)
+
+```xml
+<Languages>
+  <Language Identifier="en-US">
+    <TranslationUnit RefId="M-00FA_A-AC11-04-0000">
+      <TranslationElement RefId="M-00FA_A-AC11-04-0000_PT-OnOffYesNo_EN-0">
+        <Translation AttributeName="Text" Text="No" />
+      </TranslationElement>
+    </TranslationUnit>
+  </Language>
+</Languages>
+```
+
+## Known limitation: renumbered IDs
+
+OpenKNXproducer renumbers `_PB-` (ParameterBlock) and `_PS-` (ParameterSeparator) IDs during processing. Because the `TranslationElement/@RefId` is written from the parent element's `Id` before renumbering takes place, these entries will not match the final IDs that ETS looks up. Use explicit `TranslationElement` entries with stable IDs (e.g. derived from a `Name` attribute via XPath) as a workaround until this is resolved.

--- a/tools/translation/FindMissingTranslations.ps1
+++ b/tools/translation/FindMissingTranslations.ps1
@@ -1,0 +1,112 @@
+####################################################################################################
+# Description: Scans XML files in a directory for Text/SuffixText/FunctionText attributes
+#              that are missing an op:Translation child for the specified language.
+#              Skips debug.xml files, fully-placeholder values (%FOO%), template tokens,
+#              and values that are language-neutral (unit suffixes etc.).
+#
+# Usage:       FindMissingTranslations.ps1 [-Path <dir>] [-Language <lang>] [-Limit <n>]
+#
+# Parameters:  -Path:     Directory containing XML files to scan. Default: current directory.
+#              -Language: Target translation language identifier. Default: en-US.
+#              -Limit:    Max entries to show per file before truncating. Default: 60.
+#
+# Example:     FindMissingTranslations.ps1
+#              FindMissingTranslations.ps1 -Path src -Language de-DE
+#
+####################################################################################################
+
+param(
+    [string]$Path     = ".",
+    [string]$Language = "en-US",
+    [int]$Limit       = 60
+)
+
+$pythonScript = @"
+import xml.etree.ElementTree as ET
+from pathlib import Path
+import re
+import sys
+
+scan_dir = sys.argv[1]
+language = sys.argv[2]
+limit    = int(sys.argv[3])
+
+OP_NS = 'http://github.com/OpenKNX/OpenKNXproducer'
+
+attrs = ['Text', 'SuffixText', 'FunctionText']
+same_tokens = {
+    '', 's', 'min', 'h',
+    'O1', 'O2', 'O3', 'O4',
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'T',
+    'A/B', 'C/D', 'E/F', 'G/H',
+    'x', 'z', 'd',
+}
+placeholder_full = re.compile(r'^%[^%]+%$')
+
+files = sorted(Path(scan_dir).glob('*.xml'))
+any_missing = False
+
+for path in files:
+    if path.name.lower().endswith('debug.xml'):
+        continue
+    try:
+        tree = ET.parse(path)
+    except ET.ParseError as e:
+        print(f"{path.name}: PARSE ERROR: {e}")
+        continue
+    root = tree.getroot()
+    missing = []
+    for elem in root.iter():
+        if not isinstance(elem.tag, str):
+            continue
+        if elem.tag.startswith('{%s}' % OP_NS):
+            continue
+        for attr in attrs:
+            val = elem.attrib.get(attr)
+            if val is None:
+                continue
+            v = val.strip()
+            if v in same_tokens:
+                continue
+            if 'trans(' in v:
+                continue
+            if '{{' in v or '}}' in v:
+                continue
+            if placeholder_full.match(v):
+                continue
+            has_translation = False
+            for child in elem:
+                if child.tag == '{%s}Translation' % OP_NS:
+                    if child.attrib.get('Language') != language:
+                        continue
+                    if attr in child.attrib:
+                        has_translation = True
+                        break
+            if not has_translation:
+                missing.append((attr, val, elem.tag.split('}')[-1], elem.attrib.get('Id', ''), elem.attrib.get('Name', '')))
+    if missing:
+        any_missing = True
+        print(f"{path.name}: {len(missing)} missing")
+        for attr, val, tag, eid, name in missing[:limit]:
+            print(f"  [{attr}] {val!r}  <{tag}>  Id={eid}  Name={name}")
+        if len(missing) > limit:
+            print(f"  ... and {len(missing) - limit} more")
+    else:
+        print(f"{path.name}: complete")
+
+sys.exit(1 if any_missing else 0)
+"@
+
+$resolvedPath = Resolve-Path $Path -ErrorAction Stop
+
+$tmpFile = [System.IO.Path]::GetTempFileName() + ".py"
+[System.IO.File]::WriteAllText($tmpFile, $pythonScript, [System.Text.UTF8Encoding]::new($false))
+
+try {
+    & python $tmpFile $resolvedPath $Language $Limit
+    $exitCode = $LASTEXITCODE
+} finally {
+    Remove-Item $tmpFile -ErrorAction SilentlyContinue
+}
+
+exit $exitCode


### PR DESCRIPTION
ETS expects translations to be included as `Languages`/`TranslationUnit`/`TranslationElement` elements under the `Manufacturer` tag. However this is problematic for OpenKNX as the config files extensively use dynamic `RefId` entries, which are computed when OpenKNXproducer compiles them. Also it means the translations live in a completely different place or even a different file to the primary language text, which makes it hard to validate translations and keep them up to date.

### `op:Translation` element

This PR adds support for an `op:Translation` element, that allows translations to be defined inline at the place where they are used. It can be added as a child to any element with attributes that should be translated.

```xml
<Enumeration Text="Nein" Value="0" Id="%ENID%">
  <op:Translation Language="en-US" Text="No" />
</Enumeration>
```

Multiple attributes can be translated, not just `Text` attributes:

```xml
<ComObject Id="%AID%_O-%TT%00007" Text="Diagnose" FunctionText="Diagnoseobjekt">
  <op:Translation Language="en-US" Text="Diagnostics" FunctionText="Diagnostic object" />
</ComObject>
```

During compilation OpenKNXproducer converts these into proper `TranslationElement` entries with the correct resolved `RefId`, then removes the inline nodes. The output XML is identical to what a hand-written translation block would produce.

`op:Translation` elements inside templates (channel definitions, etc.) can use the same placeholders as the parent element. OpenKNXproducer resolves these placeholders during template expansion, so translations that include channel-specific text work correctly:

```xml
<ComObject Id="%AID%_O-%TT%00008" Text="DFA %C%, Eingang 8" FunctionText="Eingang 8">
  <op:Translation Language="en-US" Text="DFA %C%, input 8" FunctionText="Input 8" />
</ComObject>
```

After expansion for channel 3 this produces a `TranslationElement` with `Text="DFA 3, input 8"`.

### Audit Script

An audit script has been added to find elements with missing translations. `tools/translation/FindMissingTranslations.ps1 scans XML files for `Text`/`SuffixText`/`FunctionText` attributes that are missing an `op:Translation` element for a given language.

### Testing

I am working on adding English translations for the entire OAM-StateEngine application and it's dependent modules. An example of what the translations look like for OGM-Common can be seen here:

https://github.com/OpenKNX/OGM-Common/compare/v1...lucaspiller:OGM-Common:en

When imported into ETS the resulting product will use the language set by "Preferred Product Language" in ETS settings. If a translation for that language is not available, it will fall back to the default language. Note that in ETS 6.4 there does not appear to be a way to change the language, or update translations, after it has been imported, you need to delete the application and reload it.

<img width="845" height="555" alt="Screenshot 2026-03-03 at 22 53 07" src="https://github.com/user-attachments/assets/b0969ac9-5d9d-4441-a390-9c434d3f6cbc" />

<img width="395" height="339" alt="Screenshot 2026-03-04 at 00 17 22" src="https://github.com/user-attachments/assets/f47787eb-a52c-47dd-a3cd-0a2379f4bc15" />
